### PR TITLE
fix(py3.10-cuda12.1.1-cudnn8-devel-ubuntu22.04): wrong base image CUD…

### DIFF
--- a/docker/py3.10-cuda12.1.1-cudnn8-devel-ubuntu22.04/Dockerfile
+++ b/docker/py3.10-cuda12.1.1-cudnn8-devel-ubuntu22.04/Dockerfile
@@ -1,5 +1,5 @@
 # FROM nvidia/cuda:12.1.1-cudnn8-devel-ubuntu22.04
-FROM nvidia/cuda@sha256:217134b60289ced62b47463be32584329baf35cb55a9ccda6626b91bd59803be 
+FROM nvidia/cuda@sha256:21196d81f56b48dbee70494d5f10322e1a77cc47ffe202a3bf68eab81533c20f
 #checkov:skip=CKV_DOCKER_2: "Ensure that HEALTHCHECK instructions have been added to container images"
 
 # OCI Labels will be added using GitHub Actions


### PR DESCRIPTION
…A version

<!--- Provide a general summary of your changes in the Title above -->

## Description
Base image was using CUDA 12.2.2 which is not the CUDA version this image is aiming to support.

Now base image is `nvidia/cuda:12.1.1-cudnn8-devel-ubuntu22.04`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other changes (ci configuration, documentation or any other kind of changes)
