### PR TITLE
fix(all): Update setuptools library to all runtimes

### DIFF
--- a/docker/py3.10-cuda11.8.0-devel-ubuntu22.04/Dockerfile
+++ b/docker/py3.10-cuda11.8.0-devel-ubuntu22.04/Dockerfile
@@ -144,9 +144,8 @@ RUN \
 # ------------------------------------------------------------------
 RUN python -m pip --no-cache-dir install --upgrade \
     pip==23.0.1 \
-    setuptools==67.2.0 \
-    wheel==0.38.4 \
-    && \
+    setuptools==75.5.0 \
+    wheel==0.38.4 && \
     python -m pip --no-cache-dir install --upgrade --ignore-installed \
     pycrypto==2.6.1 \
     future==0.18.3 \

--- a/docker/py3.10-cuda11.8.0-runtime-ubuntu22.04/Dockerfile
+++ b/docker/py3.10-cuda11.8.0-runtime-ubuntu22.04/Dockerfile
@@ -142,9 +142,8 @@ RUN \
 # ------------------------------------------------------------------
 RUN python -m pip --no-cache-dir install --upgrade \
     pip==23.0.1 \
-    setuptools==67.2.0 \
-    wheel==0.38.4 \
-    && \
+    setuptools==75.5.0 \
+    wheel==0.38.4 && \
     python -m pip --no-cache-dir install --upgrade --ignore-installed \
     pycrypto==2.6.1 \
     future==0.18.3 \

--- a/docker/py3.10-cuda12.1.1-cudnn8-devel-ubuntu22.04/Dockerfile
+++ b/docker/py3.10-cuda12.1.1-cudnn8-devel-ubuntu22.04/Dockerfile
@@ -144,9 +144,8 @@ RUN \
 # ------------------------------------------------------------------
 RUN python -m pip --no-cache-dir install --upgrade \
     pip==23.0.1 \
-    setuptools==67.2.0 \
-    wheel==0.38.4 \
-    && \
+    setuptools==75.5.0 \
+    wheel==0.38.4 && \
     python -m pip --no-cache-dir install --upgrade --ignore-installed \
     pycrypto==2.6.1 \
     future==0.18.3 \

--- a/docker/py3.10-cuda12.4.1-cudnn9-devel-ubuntu22.04/Dockerfile
+++ b/docker/py3.10-cuda12.4.1-cudnn9-devel-ubuntu22.04/Dockerfile
@@ -121,9 +121,8 @@ RUN \
 # ------------------------------------------------------------------
 RUN python -m pip --no-cache-dir install --upgrade \
     pip==23.0.1 \
-    setuptools==67.2.0 \
-    wheel==0.38.4 \
-    && \
+    setuptools==75.5.0 \
+    wheel==0.38.4 && \
     python -m pip --no-cache-dir install --upgrade --ignore-installed \
     pycrypto==2.6.1 \
     future==0.18.3 \


### PR DESCRIPTION
Update setuptools.

## Description
Upgrade setuptools to the 75.5.0 version. 

## Motivation and Context
There is an issue when installing the `pycollada` package. The latest changes made in the runtimes install a new setuptools version, the latest one, and trying to reinstall the `67.2.0` version failed to do it, and it leaves the setuptools in a corrupted state.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other changes (ci configuration, documentation or any other kind of changes)

## Checklist:
I've built the images locally without using the cache to avoid any cache layer issue, and I've tried to install the `pycollada` package.
- [X] I have created tests for my code changes, and the tests are passing.
- [ ] I have executed the pre-commit hooks locally.
- [ ] My change requires a change to the documentation (create a new issue if the documentation has not been updated).
- [ ] I have updated the documentation accordingly.
